### PR TITLE
feat: add option to skip OGP image generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "astro": "astro",
     "build": "astro build",
+    "build:local": "SKIP_OG_GENERATION=true astro build",
     "create-post": "pnpm --filter create-post start",
     "dev": "astro dev",
     "fix": "run-s fix:eslint fix:prettier fix:textlint",

--- a/src/lib/environments.test.ts
+++ b/src/lib/environments.test.ts
@@ -79,3 +79,76 @@ describe("isProduction", () => {
     expect(isProduction).toBe(false);
   });
 });
+
+describe("shouldSkipOgGeneration", () => {
+  const originalSkipOgGeneration = process.env.SKIP_OG_GENERATION;
+
+  beforeEach(() => {
+    // Clear the module cache to ensure fresh imports
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    // Restore original SKIP_OG_GENERATION
+    if (originalSkipOgGeneration !== undefined) {
+      process.env.SKIP_OG_GENERATION = originalSkipOgGeneration;
+    } else {
+      delete process.env.SKIP_OG_GENERATION;
+    }
+  });
+
+  it("should return true when SKIP_OG_GENERATION is 'true'", async () => {
+    // Arrange
+    process.env.SKIP_OG_GENERATION = "true";
+
+    // Act
+    const { shouldSkipOgGeneration } = await import("./environments");
+
+    // Assert
+    expect(shouldSkipOgGeneration).toBe(true);
+  });
+
+  it("should return false when SKIP_OG_GENERATION is 'false'", async () => {
+    // Arrange
+    process.env.SKIP_OG_GENERATION = "false";
+
+    // Act
+    const { shouldSkipOgGeneration } = await import("./environments");
+
+    // Assert
+    expect(shouldSkipOgGeneration).toBe(false);
+  });
+
+  it("should return false when SKIP_OG_GENERATION is undefined", async () => {
+    // Arrange
+    delete process.env.SKIP_OG_GENERATION;
+
+    // Act
+    const { shouldSkipOgGeneration } = await import("./environments");
+
+    // Assert
+    expect(shouldSkipOgGeneration).toBe(false);
+  });
+
+  it("should return false when SKIP_OG_GENERATION is empty string", async () => {
+    // Arrange
+    process.env.SKIP_OG_GENERATION = "";
+
+    // Act
+    const { shouldSkipOgGeneration } = await import("./environments");
+
+    // Assert
+    expect(shouldSkipOgGeneration).toBe(false);
+  });
+
+  it("should return false for any other SKIP_OG_GENERATION value", async () => {
+    // Arrange
+    process.env.SKIP_OG_GENERATION = "1";
+
+    // Act
+    const { shouldSkipOgGeneration } = await import("./environments");
+
+    // Assert
+    expect(shouldSkipOgGeneration).toBe(false);
+  });
+});

--- a/src/lib/environments.ts
+++ b/src/lib/environments.ts
@@ -1,1 +1,3 @@
 export const isProduction = process.env.NODE_ENV === "production";
+
+export const shouldSkipOgGeneration = process.env.SKIP_OG_GENERATION === "true";

--- a/src/pages/og/[slug].png.ts
+++ b/src/pages/og/[slug].png.ts
@@ -1,4 +1,5 @@
 import { getOgImage } from "@/components/OgpImage";
+import { shouldSkipOgGeneration } from "@/lib/environments";
 import { getPosts } from "@/lib/repositories/posts";
 import type { APIContext } from "astro";
 import { getEntry } from "astro:content";
@@ -14,6 +15,14 @@ export async function getStaticPaths() {
 export async function GET({ params }: APIContext) {
   if (!params.slug) {
     throw new Error("Slug not found");
+  }
+
+  // OGP画像生成をスキップする場合は404を返す
+  if (shouldSkipOgGeneration) {
+    return new Response("OGP image generation is skipped", {
+      status: 404,
+      headers: { "Content-Type": "text/plain" },
+    });
   }
 
   const post = await getEntry("posts", params.slug);

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -3,6 +3,7 @@ import { render, type CollectionEntry } from "astro:content";
 import Tag from "@/components/Tag.astro";
 import Layout from "@/layouts/Layout.astro";
 import { cdateJST } from "@/lib/cdate-jst";
+import { shouldSkipOgGeneration } from "@/lib/environments";
 import { getPosts } from "@/lib/repositories/posts";
 import "@/styles/markdown-body.css";
 import { Image } from "astro:assets";
@@ -26,6 +27,11 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+
+// OGP画像のURLを条件によって設定
+const ogImageUrl = shouldSkipOgGeneration
+  ? undefined
+  : new URL(`/og/${post.id}.png`, Astro.url.origin).toString();
 ---
 
 <Layout
@@ -34,7 +40,7 @@ const { Content } = await render(post);
   seo={{
     openGraph: {
       type: "article",
-      image: new URL(`/og/${post.id}.png`, Astro.url.origin).toString(),
+      image: ogImageUrl,
     },
   }}
 >


### PR DESCRIPTION
## Summary
- Add support for `SKIP_OG_GENERATION` environment variable to skip OGP image generation
- Add `build:local` script for local development without OGP image generation
- Add comprehensive tests for the new functionality

## Changes
- **environments.ts**: Add `shouldSkipOgGeneration` function
- **og/[slug].png.ts**: Return 404 when OGP generation is skipped
- **posts/[id].astro**: Conditionally set OGP image URL
- **package.json**: Add `build:local` script
- **environments.test.ts**: Add tests for `shouldSkipOgGeneration`

## Test plan
- [x] Add unit tests for `shouldSkipOgGeneration` function
- [x] Test with `SKIP_OG_GENERATION=true` environment variable
- [x] Test with `SKIP_OG_GENERATION=false` environment variable
- [x] Test with undefined `SKIP_OG_GENERATION` environment variable
- [x] Verify `build:local` script works correctly

Fixes #794

🤖 Generated with [Claude Code](https://claude.ai/code)