### PR TITLE
Add vitest coverage report integration with GitHub Actions

### DIFF
--- a/.container-use/AGENT.md
+++ b/.container-use/AGENT.md
@@ -1,0 +1,1 @@
+No instructions found. Please look around the filesystem and update me

--- a/.container-use/AGENT.md
+++ b/.container-use/AGENT.md
@@ -1,1 +1,1 @@
-Development environment for Astro blog project with Node.js 22 and pnpm 9. Available commands: pnpm install, pnpm test, pnpm test:coverage (to be added), pnpm lint, pnpm build
+Development environment for Astro blog project with Node.js 22 and pnpm 10.12.1. Available commands: pnpm install, pnpm test, pnpm test:coverage (to be added), pnpm lint, pnpm build

--- a/.container-use/AGENT.md
+++ b/.container-use/AGENT.md
@@ -1,1 +1,1 @@
-No instructions found. Please look around the filesystem and update me
+Development environment for Astro blog project with Node.js 22 and pnpm 9. Available commands: pnpm install, pnpm test, pnpm test:coverage (to be added), pnpm lint, pnpm build

--- a/.container-use/environment.json
+++ b/.container-use/environment.json
@@ -1,0 +1,5 @@
+{
+  "workdir": "/workdir",
+  "base_image": "ubuntu:24.04",
+  "Locked": false
+}

--- a/.container-use/environment.json
+++ b/.container-use/environment.json
@@ -1,5 +1,12 @@
 {
   "workdir": "/workdir",
   "base_image": "ubuntu:24.04",
+  "setup_commands": [
+    "apt-get update",
+    "apt-get install -y curl gnupg2 software-properties-common",
+    "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",
+    "apt-get install -y nodejs",
+    "npm install -g pnpm@9"
+  ],
   "Locked": false
 }

--- a/.container-use/environment.json
+++ b/.container-use/environment.json
@@ -6,7 +6,7 @@
     "apt-get install -y curl gnupg2 software-properties-common",
     "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",
     "apt-get install -y nodejs",
-    "npm install -g pnpm@9"
+    "npm install -g pnpm@10.12.1"
   ],
   "Locked": false
 }

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build-and-preview:
     runs-on: ubuntu-latest
@@ -36,9 +40,16 @@ jobs:
         run: git diff --exit-code pnpm-lock.yaml
       - name: Test with Coverage
         run: |
-          pnpm test -- --coverage
+          pnpm test:coverage
         env:
           CI: true
+      - name: Vitest Coverage Report
+        uses: davelosert/vitest-coverage-report-action@v2
+        if: always()
+        with:
+          json-summary-path: './coverage/coverage-summary.json'
+          json-final-path: './coverage/coverage-final.json'
+          file-coverage-mode: 'changes'
       - name: Lint
         run: |
           pnpm lint

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "preview": "astro preview",
     "start": "astro dev",
     "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "test:run": "vitest run"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     },
     coverage: {
       provider: "v8",
-      reporter: ["text", "json", "html"],
+      reporter: ["text", "json", "html", "json-summary"],
       include: ["src/**/*", "tools/**/*"],
       exclude: ["**/*.test.*", "**/*.config.*", "**/*.d.ts"],
     },


### PR DESCRIPTION
## Summary
- Add `pnpm test:coverage` script for easy coverage report generation
- Integrate vitest-coverage-report GitHub Action for automatic PR comments
- Add json-summary reporter to vitest config for GitHub Actions compatibility

## Changes
- **package.json**: Added `test:coverage` script
- **vitest.config.ts**: Added `json-summary` reporter to coverage configuration  
- **.github/workflows/lint-and-build.yml**: Added permissions and vitest-coverage-report action integration

## Test plan
- [x] Verified `pnpm test:coverage` generates coverage reports correctly
- [x] Confirmed coverage-summary.json and coverage-final.json are created
- [ ] Test GitHub Actions workflow generates PR comments (will be tested when PR is created)

🤖 Generated with [Claude Code](https://claude.ai/code)