### PR TITLE
fix(styles): ensure remark-card width extends to full main container

### DIFF
--- a/src/styles/markdown-body.css
+++ b/src/styles/markdown-body.css
@@ -47,7 +47,7 @@
 }
 
 .markdown-body .remark-card a {
-  @apply block rounded-lg border border-gray-200 bg-white px-6 shadow-sm hover:bg-neutral-50;
+  @apply block w-full! rounded-lg border border-gray-200 bg-white px-6 shadow-sm hover:bg-neutral-50;
   @apply hover:no-underline;
 }
 


### PR DESCRIPTION
## Summary
Fixed remark-card (OGP card) width to properly extend to the full container width within markdown body.

## Changes
- Added `w-full!` (Tailwind CSS v4 `!important` modifier) to `.markdown-body .remark-card a`
- This overrides `width: fit-content` from `github-markdown-css` which was winning due to higher specificity

## Review Points
- Verify OGP cards display at full container width
- Confirm no impact on other link styles within markdown body