### PR TITLE
chore: harness improvements (AAA enforcement, README living context, unused-disable detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # blog
 
-https://blog.70-10.net
+Personal blog built with Astro 5, published at https://blog.70-10.net.
+
+## Documentation
+
+- [AGENTS.md](./AGENTS.md) — Development guide and architecture overview (shared between contributors and AI agents such as Claude Code)
+
+## Common commands
+
+| Command            | Purpose                                  |
+| ------------------ | ---------------------------------------- |
+| `pnpm dev`         | Start the dev server                     |
+| `pnpm build:local` | Local build (skips OGP image generation) |
+| `pnpm test:run`    | Run the test suite                       |
+| `pnpm lint`        | Run every linter                         |
+| `pnpm create-post` | Create a new blog post                   |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,78 @@ import eslintConfigPrettier from "eslint-config-prettier";
 import astroPlugin from "eslint-plugin-astro";
 import globals from "globals";
 
+const AAA_LABELS = ["Arrange", "Act", "Assert"];
+const AAA_PATTERNS = AAA_LABELS.map((label) => new RegExp(`\\b${label}\\b`));
+
+const localPlugin = {
+  rules: {
+    "require-aaa-comments": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "Require // Arrange, // Act, // Assert comments in each test body.",
+        },
+        schema: [],
+        messages: {
+          missing:
+            "Missing AAA comment(s) in test body: {{missing}}. Add `// Arrange`, `// Act`, and `// Assert` to mark sections.",
+        },
+      },
+      create(context) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        return {
+          CallExpression(node) {
+            const callee = node.callee;
+            const calleeName =
+              callee.type === "Identifier"
+                ? callee.name
+                : callee.type === "MemberExpression" &&
+                    callee.property.type === "Identifier"
+                  ? callee.property.name
+                  : null;
+            if (calleeName !== "it" && calleeName !== "test") return;
+
+            const callback = node.arguments.find(
+              (arg) =>
+                arg &&
+                (arg.type === "ArrowFunctionExpression" ||
+                  arg.type === "FunctionExpression"),
+            );
+            if (
+              !callback ||
+              !callback.body ||
+              callback.body.type !== "BlockStatement"
+            )
+              return;
+
+            const comments = sourceCode.getCommentsInside(callback.body);
+            const lineTexts = comments
+              .filter((c) => c.type === "Line")
+              .map((c) => c.value.trim());
+            const covered = new Set();
+            for (const text of lineTexts) {
+              for (let i = 0; i < AAA_LABELS.length; i++) {
+                if (AAA_PATTERNS[i].test(text)) {
+                  covered.add(AAA_LABELS[i]);
+                }
+              }
+            }
+            const missing = AAA_LABELS.filter((label) => !covered.has(label));
+            if (missing.length > 0) {
+              context.report({
+                node,
+                messageId: "missing",
+                data: { missing: missing.join(", ") },
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
 export default [
   {
     ignores: [
@@ -48,6 +120,18 @@ export default [
         parser: "@typescript-eslint/parser",
         extraFileExtensions: [".astro"],
       },
+    },
+  },
+  {
+    files: ["**/*.test.ts"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    plugins: { local: localPlugin },
+    rules: {
+      "local/require-aaa-comments": "error",
     },
   },
   eslintConfigPrettier,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fix:prettier": "npm run lint:prettier -- --write",
     "fix:textlint": "npm run lint:textlint -- --fix",
     "lint": "run-p lint:*",
-    "lint:eslint": "eslint . --format friendly",
+    "lint:eslint": "eslint . --format friendly --report-unused-disable-directives",
     "lint:prettier": "prettier . --check",
     "lint:textlint": "textlint src/content/posts/**/*.md",
     "prepare": "lefthook install",

--- a/src/__tests__/pages/og/[slug].png.test.ts
+++ b/src/__tests__/pages/og/[slug].png.test.ts
@@ -122,6 +122,8 @@ describe("GET", () => {
     });
 
     it("should throw error when slug is undefined", async () => {
+      // Arrange (no setup needed)
+
       // Act & Assert
       await expect(
         GET({ params: { slug: undefined } } as unknown as APIContext),
@@ -129,6 +131,8 @@ describe("GET", () => {
     });
 
     it("should throw error when slug is empty string", async () => {
+      // Arrange (no setup needed)
+
       // Act & Assert
       await expect(
         GET({ params: { slug: "" } } as unknown as APIContext),

--- a/src/components/Footer.test.ts
+++ b/src/components/Footer.test.ts
@@ -7,6 +7,8 @@ import Footer from "./Footer.astro";
 describe("Footer", () => {
   describe("Positive Cases", () => {
     it("should render footer element", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Footer);
 
@@ -15,6 +17,8 @@ describe("Footer", () => {
     });
 
     it("should contain privacy policy link", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Footer);
 
@@ -24,6 +28,8 @@ describe("Footer", () => {
     });
 
     it("should contain GitHub link", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Footer);
 

--- a/src/components/Header.test.ts
+++ b/src/components/Header.test.ts
@@ -22,6 +22,8 @@ async function renderHeader(props: Record<string, unknown>) {
 describe("Header", () => {
   describe("Positive Cases", () => {
     it("should display site title 'mnml'", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderHeader({ displayBackButton: false });
 
@@ -30,6 +32,8 @@ describe("Header", () => {
     });
 
     it("should include link to top page", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderHeader({ displayBackButton: false });
 
@@ -38,6 +42,8 @@ describe("Header", () => {
     });
 
     it("should render header element", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderHeader({ displayBackButton: false });
 
@@ -46,6 +52,8 @@ describe("Header", () => {
     });
 
     it("should render back button with ArrowLeft icon when displayBackButton is true", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderHeader({ displayBackButton: true });
 
@@ -56,6 +64,8 @@ describe("Header", () => {
 
   describe("Negative Cases", () => {
     it("should not render back button when displayBackButton is false", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderHeader({ displayBackButton: false });
 

--- a/src/components/OgpImage.test.ts
+++ b/src/components/OgpImage.test.ts
@@ -35,6 +35,8 @@ describe("getOgImage", () => {
 
   describe("Positive Cases", () => {
     it("should return a Buffer", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const result = await getOgImage("Test Title");
 
@@ -61,6 +63,8 @@ describe("getOgImage", () => {
     });
 
     it("should fetch Google Fonts API", async () => {
+      // Arrange (no setup needed)
+
       // Act
       await getOgImage("Test");
 
@@ -87,6 +91,8 @@ describe("getOgImage", () => {
 
   describe("Edge Cases", () => {
     it("should handle empty text", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const result = await getOgImage("");
 

--- a/src/components/ProfileCard.test.ts
+++ b/src/components/ProfileCard.test.ts
@@ -7,6 +7,8 @@ import ProfileCard from "./ProfileCard.astro";
 describe("ProfileCard", () => {
   describe("Positive Cases", () => {
     it("should display profile name", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(ProfileCard);
 
@@ -15,6 +17,8 @@ describe("ProfileCard", () => {
     });
 
     it("should contain X link", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(ProfileCard);
 
@@ -23,6 +27,8 @@ describe("ProfileCard", () => {
     });
 
     it("should contain GitHub link", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(ProfileCard);
 

--- a/src/components/ReadingProgressBar.test.ts
+++ b/src/components/ReadingProgressBar.test.ts
@@ -7,6 +7,8 @@ import ReadingProgressBar from "./ReadingProgressBar.astro";
 describe("ReadingProgressBar", () => {
   describe("Positive Cases", () => {
     it("should render progress element", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(ReadingProgressBar);
 
@@ -15,6 +17,8 @@ describe("ReadingProgressBar", () => {
     });
 
     it("should have correct id attribute", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(ReadingProgressBar);
 
@@ -23,6 +27,8 @@ describe("ReadingProgressBar", () => {
     });
 
     it("should have initial value of 0", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(ReadingProgressBar);
 
@@ -31,6 +37,8 @@ describe("ReadingProgressBar", () => {
     });
 
     it("should have max value of 100", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(ReadingProgressBar);
 

--- a/src/components/Tag.test.ts
+++ b/src/components/Tag.test.ts
@@ -7,6 +7,8 @@ import Tag from "./Tag.astro";
 describe("Tag", () => {
   describe("Positive Cases", () => {
     it("should display tag name with hash prefix", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Tag, {
         props: { name: "javascript" },
@@ -17,6 +19,8 @@ describe("Tag", () => {
     });
 
     it("should generate correct tag link", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Tag, {
         props: { name: "javascript" },
@@ -27,6 +31,8 @@ describe("Tag", () => {
     });
 
     it("should render as anchor element", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Tag, { props: { name: "test" } });
 
@@ -37,6 +43,8 @@ describe("Tag", () => {
 
   describe("Edge Cases", () => {
     it("should keep plus signs in tag name URL", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Tag, { props: { name: "C++" } });
 
@@ -47,6 +55,8 @@ describe("Tag", () => {
     });
 
     it("should encode multibyte characters in tag name URL", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const html = await renderComponent(Tag, { props: { name: "日本語" } });
 

--- a/tools/remark-ogp-card/index.test.ts
+++ b/tools/remark-ogp-card/index.test.ts
@@ -86,6 +86,8 @@ describe("remark-ogp-card utilities", () => {
 
     describe("Negative Cases", () => {
       it("should throw error for invalid URL", () => {
+        // Arrange (no setup needed)
+
         // Act & Assert
         expect(() => generateURL("not a valid url")).toThrow();
       });
@@ -169,16 +171,22 @@ describe("remark-ogp-card utilities", () => {
   describe("htmlEncode", () => {
     describe("Positive Cases", () => {
       it("should encode ampersand", () => {
+        // Arrange (no setup needed)
+
         // Act & Assert
         expect(htmlEncode("Rock & Roll")).toBe("Rock &amp; Roll");
       });
 
       it("should encode less than and greater than", () => {
+        // Arrange (no setup needed)
+
         // Act & Assert
         expect(htmlEncode("value < 10 > 5")).toBe("value &lt; 10 &gt; 5");
       });
 
       it("should encode quotes", () => {
+        // Arrange (no setup needed)
+
         // Act & Assert
         expect(htmlEncode("He said \"Hello\" and 'Goodbye'")).toBe(
           "He said &quot;Hello&quot; and &#39;Goodbye&#39;",
@@ -201,11 +209,15 @@ describe("remark-ogp-card utilities", () => {
 
     describe("Edge Cases", () => {
       it("should handle empty string", () => {
+        // Arrange (no setup needed)
+
         // Act & Assert
         expect(htmlEncode("")).toBe("");
       });
 
       it("should handle string with no special characters", () => {
+        // Arrange (no setup needed)
+
         // Act & Assert
         expect(htmlEncode("Regular text with no special chars")).toBe(
           "Regular text with no special chars",
@@ -213,6 +225,8 @@ describe("remark-ogp-card utilities", () => {
       });
 
       it("should handle unicode characters", () => {
+        // Arrange (no setup needed)
+
         // Act & Assert
         expect(htmlEncode("こんにちは & 世界")).toBe("こんにちは &amp; 世界");
       });
@@ -227,6 +241,8 @@ describe("remark-ogp-card utilities", () => {
 describe("createYouTubeFrameElement", () => {
   describe("Positive Cases", () => {
     it("should return iframe HTML for valid videoId", () => {
+      // Arrange (no setup needed)
+
       // Act
       const result = createYouTubeFrameElement("dQw4w9WgXcQ");
 
@@ -241,6 +257,8 @@ describe("createYouTubeFrameElement", () => {
 
   describe("Edge Cases", () => {
     it("should return empty string for empty videoId", () => {
+      // Arrange (no setup needed)
+
       // Act & Assert
       expect(createYouTubeFrameElement("")).toBe("");
     });
@@ -248,6 +266,8 @@ describe("createYouTubeFrameElement", () => {
 
   describe("Negative Cases", () => {
     it("should return empty string for null videoId", () => {
+      // Arrange (no setup needed)
+
       // Act & Assert
       expect(createYouTubeFrameElement(null)).toBe("");
     });
@@ -385,6 +405,8 @@ describe("ogpCardPlugin", () => {
     });
 
     it("should convert YouTube URL to iframe", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const tree = await processMarkdown(
         "https://www.youtube.com/watch?v=test123\n",
@@ -399,6 +421,8 @@ describe("ogpCardPlugin", () => {
 
   describe("Edge Cases", () => {
     it("should not convert URL embedded in text", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const tree = await processMarkdown(
         "Check out https://example.com for more\n",
@@ -410,6 +434,8 @@ describe("ogpCardPlugin", () => {
     });
 
     it("should not convert multiple URLs in paragraph", async () => {
+      // Arrange (no setup needed)
+
       // Act
       const tree = await processMarkdown(
         "https://example.com https://example.org\n",


### PR DESCRIPTION
## Summary

ハーネス（AI エージェント支持構造）診断の結果に基づき、CLAUDE.md / AGENTS.md の推論的ガイドの一部を決定論的センサーへ昇格し、Living Context を整備する変更です。

### A. ESLint カスタムルール `require-aaa-comments`

- `eslint.config.mjs` にインライン local plugin を追加
- 各 `it` / `test` ブロック body 内に `// Arrange` / `// Act` / `// Assert` コメントが揃っているかを検査
- 対象: `**/*.test.ts`、severity: `error`
- これまで `AGENTS.md` に文章ルールとして書かれていた AAA コメント規約が、機械的に強制されるようになります
- 同 config エントリで `globals.node` を有効化（テストの `Buffer` / `process` などが `no-undef` で誤検知されないように）
- 既存テスト 8 ファイル（Footer / Header / OgpImage / ProfileCard / ReadingProgressBar / Tag / og slug / remark-ogp-card）に `// Arrange (no setup needed)` コメントを補完

### C. README を Living Context 入口に

- 2 行のプレースホルダだった README を、`AGENTS.md` への導線と主要コマンド表で構成
- 開発者・AI エージェント双方の最初の入口を最小コストで整備

### D. `--report-unused-disable-directives` を `lint:eslint` に追加

- 不要になった `eslint-disable` コメントを CI で検出可能に

## Test plan

- [x] `pnpm lint:eslint` (with `--report-unused-disable-directives`) — exit 0
- [x] `pnpm test:run` — 110 passed (13 files)
- [x] `pnpm typecheck` (`astro check`) — 0 errors
- [x] AAA ルールが意図通りに違反検出することを既存テスト群で確認（修正前は 25 件検出、修正後 0 件）
- [x] simplify レビューの指摘（RegExp ホットパス再生成）を反映済み（モジュールスコープで事前コンパイル化）