### PR TITLE
chore(prettier): ignore .claude/ local files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules/**
 **/*.d.ts
 dist/
 pnpm-lock.yaml
+.claude/


### PR DESCRIPTION
## Changes

- Add `.claude/` to `.prettierignore`

## Why

`prettier . --check` (`pnpm lint:prettier`) picks up local-only files under `.claude/` (Claude Code plans, `settings.local.json`, worktrees) and fails with exit 1, even though repository content is clean. These files are not tracked by git and should not be subject to formatting checks.